### PR TITLE
[PKG-4240] 0.4.1 initial

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   # numpy <1.24 not available for python 3.12
-  skip: True  # [py<37 or py>311]
+  # numba not available on s390x
+  skip: True  # [py<37 or py>311 or s390x]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,26 +44,10 @@ about:
   summary: Hierarchical Methods Time series forecasting
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
   description: |
-    **HierarchicalForecast** offers a collection of reconciliation methods, 
-    including `BottomUp`, `TopDown`, `MiddleOut`, `MinTrace` and `ERM`. 
-
-    ## 🎊 Features 
-
-    * Classic reconciliation methods:
-        - `BottomUp`: Simple addition to the upper levels.
-        - `TopDown`: Distributes the top levels forecasts trough the hierarchies.
-
-    * Alternative reconciliation methods:
-        - `MiddleOut`: It anchors the base predictions in a middle level. The levels 
-          above the base predictions use the bottom-up approach, while the levels below 
-          use a top-down.
-        - `MinTrace`: Minimizes the total forecast variance of the space of coherent 
-          forecasts, with the Minimum Trace reconciliation.
-        - `ERM`: Optimizes the reconciliation matrix minimizing an L1 regularized objective.
-
-    PyPI: [https://pypi.org/project/hierarchicalforecast/](https://pypi.org/project/hierarchicalforecast/)
-
+    HierarchicalForecast offers a collection of reconciliation methods, 
+    including BottomUp, TopDown, MiddleOut, MinTrace and ERM.
   doc_url: https://nixtla.github.io/hierarchicalforecast/
   dev_url: https://github.com/Nixtla/hierarchicalforecast
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,9 @@ source:
   sha256: 6add2a50f3536a7df045e28c366e72b8c71b5782cd477a95ad9f9821be886cc3
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  # numpy <1.24 not available for python 3.12
+  skip: True  # [py<37 or py>311]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,16 +18,16 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - wheel
+    - setuptools
   run:
-    - python >=3.7
+    - python
     - numba
     - numpy <1.24
     - pandas
     - scikit-learn
     - quadprog
-    - packaging
-    - statsmodels
     - matplotlib-base
     - tqdm
 


### PR DESCRIPTION
hierarchicalforecast 0.4.1

**Destination channel:** Snowflake

### Links

- [PKG-4212](https://anaconda.atlassian.net/browse/PKG-4212) 
- [Upstream repository](https://github.com/Nixtla/hierarchicalforecast/tree/main/)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/quadprog-feedstock/pull/1

### Explanation of changes:

- No tests accessible.
- Skipping python 3.12 due to missing `numpy <1.24`


[PKG-4212]: https://anaconda.atlassian.net/browse/PKG-4212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ